### PR TITLE
filter player that replaced, if     isReplaced: 'True'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/zapp-pipes-provider-ibsl-ds",
-  "version": "0.0.67",
+  "version": "0.1.0",
   "description": "data source plugin for IBSL (Israeli basketball association)",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
-    "@applicaster/zapp-pipes-dev-kit": "^1.2.1",
+    "@applicaster/zapp-pipes-dev-kit": "^1.4.1",
     "babel-cli": "^6.24.0",
     "babel-jest": "^22.4.1",
     "babel-loader": "^7.1.2",

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -3,14 +3,14 @@
     "platform": null,
     "author_name": "Maxi Wainberg",
     "author_email": "m.wainberg@applicaster.com",
-    "manifest_version": "0.0.67",
+    "manifest_version": "0.1.0",
     "name": "Zapp Pipes Provider IBSL",
     "description": "data source plugin for IBSL (Israeli basketball association)",
     "type": "data_source_provider",
     "identifier": "ibsl-ds",
     "ui_builder_support": true,
     "dependency_name": "@applicaster/zapp-pipes-provider-ibsl-ds",
-    "dependency_version": "0.0.67",
+    "dependency_version": "0.1.0",
     "dependency_repository_url": [
         "https://github.com/applicaster/zapp-pipes-provider-ibsl-ds"
     ],

--- a/src/provider/handler/ibsl/getPlayers.js
+++ b/src/provider/handler/ibsl/getPlayers.js
@@ -13,6 +13,9 @@ async function getPlayers(url) {
         return await axios
             .get(finalUrl)
             .then(players => players.data)
+            .then(data => data.players.filter( player => {
+                return (/false/i).test(player.isReplaced)
+            }))
             .then(_handlePlayers)
             .catch(err => _errorObject);
     }
@@ -30,7 +33,7 @@ const _errorObject = {
     extensions: {}
 }
 
-function _handlePlayers({ players }) {
+function _handlePlayers( players ) {    
     return {
         id: 'players',
         title: 'שחקנים',
@@ -78,5 +81,6 @@ function _handlePlayers({ players }) {
     }
 
 }
+
 
 export default getPlayers;


### PR DESCRIPTION
This PR filter from the entries list players that replaced (     isReplaced: 'True' ) , in addition i updated the applicaster zapp kit to the lates in order to support node version 10.