### PR TITLE
Fix news id not correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/zapp-pipes-provider-ibsl-ds",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "data source plugin for IBSL (Israeli basketball association)",
   "main": "lib/index.js",
   "scripts": {

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -3,14 +3,14 @@
     "platform": null,
     "author_name": "Maxi Wainberg",
     "author_email": "m.wainberg@applicaster.com",
-    "manifest_version": "0.1.0",
+    "manifest_version": "0.1.1",
     "name": "Zapp Pipes Provider IBSL",
     "description": "data source plugin for IBSL (Israeli basketball association)",
     "type": "data_source_provider",
     "identifier": "ibsl-ds",
     "ui_builder_support": true,
     "dependency_name": "@applicaster/zapp-pipes-provider-ibsl-ds",
-    "dependency_version": "0.1.0",
+    "dependency_version": "0.1.1",
     "dependency_repository_url": [
         "https://github.com/applicaster/zapp-pipes-provider-ibsl-ds"
     ],

--- a/src/provider/handler/ibsl/getNews.js
+++ b/src/provider/handler/ibsl/getNews.js
@@ -14,7 +14,7 @@ export default async function getNews(url) {
         return await axios
             .get(finalUrl)
             .then(news => news.data)
-            .then(_handleNews)
+            .then( data => _handleNews(data, team_uid == 0))
             .catch(_errorObject);
     }
 
@@ -32,7 +32,7 @@ const _errorObject = {
     extensions: {}
 }
 
-function _handleNews({ news }) {
+function _handleNews({ news }, shouldUseArtID) {
     return {
         id: 'news',
         title: 'חדשות',
@@ -43,7 +43,7 @@ function _handleNews({ news }) {
             type: {
                 value: 'link'
             },
-            id: newItem.art_id,
+            id: shouldUseArtID ? newItem.art_id : newItem.id,
             title: newItem.art_title.replace(/&#34;/g, '"').replace(/&#39;/g, "'").replace(/&quot;/g, '"'),
             summary: newItem.art_abstract.replace(/&#34;/g, '"').replace(/&#39;/g, "'").replace(/&quot;/g, '"'),
             author: {


### PR DESCRIPTION
 for the general news we now that the team_id = 0, so in this case when i see the the team_id =0  i return the art_id as part as the response otherwise the response contain the id.